### PR TITLE
CS - ignore LineLength rule

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,5 +16,8 @@
     <exclude-pattern>tests/data/*</exclude-pattern>
 
     <!-- Include all rules from the Zend Coding Standard -->
-    <rule ref="ZendCodingStandard"/>
+    <rule ref="ZendCodingStandard">
+        <exclude name="Generic.Files.LineLength"/>
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
because..

```
> phpcs
.......W 8 / 8 (100%)



FILE: tests/PHPStanRegularExpressionPatternRuleTestRerunTest.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 11 WARNINGS AFFECTING 11 LINES
----------------------------------------------------------------------
 140 | WARNING | Line exceeds 120 characters; contains 124 characters
 148 | WARNING | Line exceeds 120 characters; contains 124 characters
 156 | WARNING | Line exceeds 120 characters; contains 124 characters
 164 | WARNING | Line exceeds 120 characters; contains 124 characters
 172 | WARNING | Line exceeds 120 characters; contains 124 characters
 180 | WARNING | Line exceeds 120 characters; contains 124 characters
 188 | WARNING | Line exceeds 120 characters; contains 124 characters
 196 | WARNING | Line exceeds 120 characters; contains 124 characters
 204 | WARNING | Line exceeds 120 characters; contains 124 characters
 212 | WARNING | Line exceeds 120 characters; contains 124 characters
 220 | WARNING | Line exceeds 120 characters; contains 124 characters
----------------------------------------------------------------------
```